### PR TITLE
Adjust the service index processing

### DIFF
--- a/Zastai.NuGet.Server/Controllers/Api/ServiceIndex.cs
+++ b/Zastai.NuGet.Server/Controllers/Api/ServiceIndex.cs
@@ -1,7 +1,3 @@
-using System.Text.Json.Serialization;
-
-using JetBrains.Annotations;
-
 using Microsoft.AspNetCore.Mvc;
 
 namespace Zastai.NuGet.Server.Controllers.Api;
@@ -17,75 +13,15 @@ public sealed class ServiceIndex : ApiController<ServiceIndex> {
 
   private const string BasePath = "api/v3";
 
-  /// <summary>A NuGet v3 service index document.</summary>
-  [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
-  public sealed class Document {
-
-    private const string SchemaVersion = "3.0.0";
-
-    /// <summary>The schema version for this service index document.</summary>
-    [JsonPropertyName("version")]
-    public string Version { get; } = Document.SchemaVersion;
-
-    /// <summary>Information about a resource in a NuGet v3 service index.</summary>
-    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
-    public interface IResource {
-
-      /// <summary>The ID (an absolute URI) of the resource.</summary>
-      [JsonPropertyName("@id")]
-      Uri Uri { get; }
-
-      /// <summary>The resource type; typically in the form "<c>NAME/VERSION</c>".</summary>
-      [JsonPropertyName("@type")]
-      string Type { get; }
-
-      /// <summary>A description of the resource.</summary>
-      [JsonPropertyName("comment")]
-      string Description { get; }
-
-    }
-
-    /// <summary>The resources defined in the service index.</summary>
-    [JsonPropertyName("resources")]
-    public IEnumerable<IResource> Resources { get; }
-
-    /// <summary>Creates a new NuGet v3 service index document.</summary>
-    /// <param name="baseUri">The base URI for resources with a relative path.</param>
-    public Document(Uri baseUri) {
-      var resources = new List<Resource>();
-      Document.Add(resources, baseUri, Autocomplete.Service);
-      Document.Add(resources, baseUri, Catalog.Service);
-      Document.Add(resources, baseUri, PackageDownload.Service);
-      Document.Add(resources, baseUri, PackageDetails.Service);
-      Document.Add(resources, baseUri, PackageMetadata.Service);
-      Document.Add(resources, baseUri, PublishPackage.Service);
-      Document.Add(resources, baseUri, PublishSymbols.Service);
-      Document.Add(resources, baseUri, ReportAbuse.Service);
-      Document.Add(resources, baseUri, RepositorySignatures.Service);
-      Document.Add(resources, baseUri, Search.Service);
-      Document.Add(resources, baseUri, SymbolServer.Service);
-      this.Resources = resources;
-    }
-
-    private static void Add(ICollection<Resource> resources, Uri baseUri, NuGetService service) {
-      foreach (var type in service.Types) {
-        resources.Add(new Resource(new Uri(baseUri, service.Path), type, service.Description));
-      }
-    }
-
-    private sealed record Resource(Uri Uri, string Type, string Description) : IResource;
-
-  }
-
   /// <summary>Gets the NuGet v3 service index.</summary>
   /// <returns>The NuGet v3 service index.</returns>
   /// <response code="200">Always.</response>
   [HttpGet("index.json")]
-  public Document Get() {
+  public Documents.ServiceIndex Get() {
     // FIXME: Would it be safe to cache this? Or can the scheme/host/port differ between requests?
     var req = this.Request;
     var baseUri = new UriBuilder(req.Scheme, req.Host.Host, req.Host.Port ?? -1).Uri;
-    return new Document(baseUri);
+    return new Documents.ServiceIndex(baseUri);
   }
 
 }

--- a/Zastai.NuGet.Server/Controllers/Documents/ServiceIndex.cs
+++ b/Zastai.NuGet.Server/Controllers/Documents/ServiceIndex.cs
@@ -1,0 +1,50 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+using JetBrains.Annotations;
+
+using Zastai.NuGet.Server.Controllers.Api;
+
+namespace Zastai.NuGet.Server.Controllers.Documents;
+
+/// <summary>A NuGet v3 service index document.</summary>
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+public sealed class ServiceIndex {
+
+  private const string SchemaVersion = "3.0.0";
+
+  /// <summary>The schema version for this service index document.</summary>
+  [JsonPropertyName("version")]
+  [Required]
+  public string Version { get; } = ServiceIndex.SchemaVersion;
+
+  /// <summary>The resources defined in the service index.</summary>
+  [JsonPropertyName("resources")]
+  [Required]
+  public IEnumerable<ServiceIndexResource> Resources { get; }
+
+  /// <summary>Creates a new NuGet v3 service index document.</summary>
+  /// <param name="baseUri">The base URI for resources with a relative path.</param>
+  public ServiceIndex(Uri baseUri) {
+    var resources = new List<ServiceIndexResource>();
+    ServiceIndex.Add(resources, baseUri, Autocomplete.Service);
+    ServiceIndex.Add(resources, baseUri, Catalog.Service);
+    ServiceIndex.Add(resources, baseUri, PackageDownload.Service);
+    ServiceIndex.Add(resources, baseUri, PackageDetails.Service);
+    ServiceIndex.Add(resources, baseUri, PackageMetadata.Service);
+    ServiceIndex.Add(resources, baseUri, PublishPackage.Service);
+    ServiceIndex.Add(resources, baseUri, PublishSymbols.Service);
+    ServiceIndex.Add(resources, baseUri, ReportAbuse.Service);
+    ServiceIndex.Add(resources, baseUri, Api.RepositorySignatures.Service);
+    ServiceIndex.Add(resources, baseUri, Search.Service);
+    ServiceIndex.Add(resources, baseUri, SymbolServer.Service);
+    this.Resources = resources;
+  }
+
+  private static void Add(ICollection<ServiceIndexResource> resources, Uri baseUri, NuGetService service) {
+    foreach (var type in service.Types) {
+      resources.Add(new ServiceIndexResource(new Uri(baseUri, service.Path), type, service.Description));
+    }
+  }
+
+}

--- a/Zastai.NuGet.Server/Controllers/Documents/ServiceIndexResource.cs
+++ b/Zastai.NuGet.Server/Controllers/Documents/ServiceIndexResource.cs
@@ -1,0 +1,37 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+using JetBrains.Annotations;
+
+namespace Zastai.NuGet.Server.Controllers.Documents;
+
+/// <summary>Information about a resource in a NuGet v3 service index.</summary>
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+public class ServiceIndexResource {
+
+  /// <summary>Creates a new service index resource.</summary>
+  /// <param name="uri">The ID (an absolute URI) of the resource.</param>
+  /// <param name="type">The resource type; typically in the form "<c>NAME/VERSION</c>".</param>
+  /// <param name="description">A description of the resource.</param>
+  public ServiceIndexResource(Uri uri, string type, string description) {
+    this.Uri = uri;
+    this.Type = type;
+    this.Description = description;
+  }
+
+  /// <summary>The ID (an absolute URI) of the resource.</summary>
+  [JsonPropertyName("@id")]
+  [Required]
+  public Uri Uri { get; }
+
+  /// <summary>The resource type; typically in the form "<c>NAME/VERSION</c>".</summary>
+  [JsonPropertyName("@type")]
+  [Required]
+  public string Type { get; }
+
+  /// <summary>A description of the resource.</summary>
+  [JsonPropertyName("comment")]
+  [Required]
+  public string Description { get; }
+
+}


### PR DESCRIPTION
JSON types now have their own namespace, with clear names (using a nested `Document` class works fine technically, but does not look nice in the generated Swagger documentation).

This also marks all required fields using `[Required]`; without it, the Swagger info will mark fields of a non-nullable reference type as nullable.