### PR TITLE
Implement the `RepositorySignatures` service

### DIFF
--- a/Zastai.NuGet.Server/Controllers/Api/RepositorySignatures.cs
+++ b/Zastai.NuGet.Server/Controllers/Api/RepositorySignatures.cs
@@ -8,10 +8,18 @@ public class RepositorySignatures : ApiController<RepositorySignatures> {
 
   private const string BasePath = "repository-signatures";
 
+  private const string ActionPath = "index.json";
+
   /// <summary>Creates a new repository signatures service controller.</summary>
   /// <param name="logger">A logger for the controller.</param>
   public RepositorySignatures(ILogger<RepositorySignatures> logger) : base(logger) {
   }
+
+  /// <summary>Gets the repository signatures.</summary>
+  /// <returns>The repository signatures.</returns>
+  /// <response code="200">Always.</response>
+  [HttpGet(RepositorySignatures.ActionPath)]
+  public Documents.RepositorySignatures Index() => new();
 
   #region NuGet Service Info
 
@@ -24,8 +32,8 @@ public class RepositorySignatures : ApiController<RepositorySignatures> {
   };
 
   /// <summary>NuGet service information for the repository signatures service.</summary>
-  public static readonly NuGetService Service = new(RepositorySignatures.BasePath, RepositorySignatures.Types,
-                                                    RepositorySignatures.Description);
+  public static readonly NuGetService Service = new(RepositorySignatures.BasePath + '/' + RepositorySignatures.ActionPath,
+                                                    RepositorySignatures.Types, RepositorySignatures.Description);
 
   #endregion
 

--- a/Zastai.NuGet.Server/Controllers/Documents/CertificateFingerprints.cs
+++ b/Zastai.NuGet.Server/Controllers/Documents/CertificateFingerprints.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+using JetBrains.Annotations;
+
+namespace Zastai.NuGet.Server.Controllers.Documents;
+
+/// <summary>A set of fingerprints for a signing certificate.</summary>
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+public class CertificateFingerprints {
+
+  /// <summary>Creates a new set of fingerprints for a signing certificate.</summary>
+  /// <param name="sha256">The SHA-256 fingerprint.</param>
+  public CertificateFingerprints(string sha256) {
+    this.SHA256 = sha256;
+  }
+
+  /// <summary>The SHA-256 fingerprint.</summary>
+  [JsonPropertyName("2.16.840.1.101.3.4.2.1")]
+  [Required]
+  public string SHA256 { get; }
+
+}

--- a/Zastai.NuGet.Server/Controllers/Documents/RepositorySignatures.cs
+++ b/Zastai.NuGet.Server/Controllers/Documents/RepositorySignatures.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+using JetBrains.Annotations;
+
+namespace Zastai.NuGet.Server.Controllers.Documents;
+
+/// <summary>A NuGet repository signatures document.</summary>
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+public sealed class RepositorySignatures {
+
+  /// <summary>Indicates whether or not all packages stored in the server are signed.</summary>
+  [JsonPropertyName("allRepositorySigned")]
+  [Required]
+  public bool AllPackagesAreSigned { get; } = false;
+
+  /// <summary>The signing certificates used by the server.</summary>
+  [JsonPropertyName("signingCertificates")]
+  [Required]
+  public SigningCertificate[] Certificates { get; } = Array.Empty<SigningCertificate>();
+
+}

--- a/Zastai.NuGet.Server/Controllers/Documents/SigningCertificate.cs
+++ b/Zastai.NuGet.Server/Controllers/Documents/SigningCertificate.cs
@@ -1,0 +1,59 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+using JetBrains.Annotations;
+
+namespace Zastai.NuGet.Server.Controllers.Documents;
+
+/// <summary>Information about a certificate used to sign packages.</summary>
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+public sealed class SigningCertificate {
+
+  /// <summary>Creates information about a certificate used to sign packages.</summary>
+  /// <param name="contentUrl">Absolute URL to the DER-encoded public certificate.</param>
+  /// <param name="fingerprints">The certificate's fingerprints.</param>
+  /// <param name="issuer">The distinguished name of the certificate's issuer.</param>
+  /// <param name="notAfter">The ending timestamp of the certificate's validity period.</param>
+  /// <param name="notBefore">The starting timestamp of the certificate's validity period.</param>
+  /// <param name="subject">The subject distinguished name from the certificate.</param>
+  public SigningCertificate(Uri contentUrl, CertificateFingerprints fingerprints, string issuer, DateTimeOffset notAfter,
+                            DateTimeOffset notBefore, string subject) {
+    this.ContentUrl = contentUrl;
+    this.Fingerprints = fingerprints;
+    this.Issuer = issuer;
+    this.NotAfter = notAfter;
+    this.NotBefore = notBefore;
+    this.Subject = subject;
+  }
+
+  /// <summary>Absolute URL to the DER-encoded public certificate.</summary>
+  [JsonPropertyName("contentUrl")]
+  [Required]
+  public Uri ContentUrl { get; }
+
+  /// <summary>The certificate's fingerprints.</summary>
+  [JsonPropertyName("fingerprints")]
+  [Required]
+  public CertificateFingerprints Fingerprints { get; }
+
+  /// <summary>The distinguished name of the certificate's issuer.</summary>
+  [JsonPropertyName("issuer")]
+  [Required]
+  public string Issuer { get; }
+
+  /// <summary>The ending timestamp of the certificate's validity period.</summary>
+  [JsonPropertyName("notAfter")]
+  [Required]
+  public DateTimeOffset NotAfter { get; }
+
+  /// <summary>The starting timestamp of the certificate's validity period.</summary>
+  [JsonPropertyName("notBefore")]
+  [Required]
+  public DateTimeOffset NotBefore { get; }
+
+  /// <summary>The subject distinguished name from the certificate.</summary>
+  [JsonPropertyName("subject")]
+  [Required]
+  public string Subject { get; }
+
+}


### PR DESCRIPTION
Currently, this just returns an empty set of certificates and indicates that not all packages are signed.

This also adjusts the endpoint to be `repository-signatures/index.json`.