### PR TITLE
Implement package version enumeration

### DIFF
--- a/Zastai.NuGet.Server/Controllers/Api/PackageContent.cs
+++ b/Zastai.NuGet.Server/Controllers/Api/PackageContent.cs
@@ -25,8 +25,8 @@ public class PackageContent : ApiController<PackageContent> {
   /// <summary>Enumerates the versions available for a package.</summary>
   /// <param name="id">The package ID.</param>
   /// <returns>The versions available for a package.</returns>
-  /// <response code="200">When the package was found.</response>
-  /// <response code="404">When the package was not found.</response>
+  /// <response code="200">When the package was found and has available versions.</response>
+  /// <response code="404">When the package was not found or does not have any available versions.</response>
   [HttpGet("{id}/index.json")]
   [ProducesResponseType(typeof(PackageVersions), StatusCodes.Status200OK)]
   [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]

--- a/Zastai.NuGet.Server/Controllers/Documents/PackageVersions.cs
+++ b/Zastai.NuGet.Server/Controllers/Documents/PackageVersions.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+using JetBrains.Annotations;
+
+namespace Zastai.NuGet.Server.Controllers.Documents;
+
+/// <summary>A set of versions available for a package.</summary>
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+public class PackageVersions {
+
+  /// <summary>Creates a new set of package versions.</summary>
+  /// <param name="versions">The available versions for the package.</param>
+  public PackageVersions(IReadOnlyList<string> versions) {
+    this.Versions = versions;
+  }
+
+  /// <summary>The available versions for the package.</summary>
+  [JsonPropertyName("versions")]
+  [Required]
+  public IReadOnlyList<string> Versions { get; }
+
+}

--- a/Zastai.NuGet.Server/Controllers/Documents/ServiceIndex.cs
+++ b/Zastai.NuGet.Server/Controllers/Documents/ServiceIndex.cs
@@ -29,7 +29,7 @@ public sealed class ServiceIndex {
     var resources = new List<ServiceIndexResource>();
     ServiceIndex.Add(resources, baseUri, Autocomplete.Service);
     ServiceIndex.Add(resources, baseUri, Catalog.Service);
-    ServiceIndex.Add(resources, baseUri, PackageDownload.Service);
+    ServiceIndex.Add(resources, baseUri, PackageContent.Service);
     ServiceIndex.Add(resources, baseUri, PackageDetails.Service);
     ServiceIndex.Add(resources, baseUri, PackageMetadata.Service);
     ServiceIndex.Add(resources, baseUri, PublishPackage.Service);

--- a/Zastai.NuGet.Server/Services/IPackageStore.cs
+++ b/Zastai.NuGet.Server/Services/IPackageStore.cs
@@ -31,6 +31,11 @@ public interface IPackageStore {
   /// <returns>The ID of the user who added the package; <see langword="null"/> if the package did not exist.</returns>
   public string? GetPackageOwner(string id, string version);
 
+  /// <summary>Retrieves the available versions for a package.</summary>
+  /// <param name="id">The package ID.</param>
+  /// <returns>The versions available for the package.</returns>
+  public IReadOnlyList<string> GetPackageVersions(string id);
+
   /// <summary>Determines whether or not a give file is allowed to be downloaded.</summary>
   /// <param name="file">The file for which download is requested.</param>
   /// <returns>

--- a/Zastai.NuGet.Server/Services/PackageStore.cs
+++ b/Zastai.NuGet.Server/Services/PackageStore.cs
@@ -413,6 +413,19 @@ public class PackageStore : IPackageStore {
     return doc.DocumentElement.SelectSingleNode("./owner")?.InnerText;
   }
 
+  /// <inheritdoc />
+  public IReadOnlyList<string> GetPackageVersions(string id) {
+    var packageDir = Path.Combine(this.PackageFolder, id);
+    if (!Directory.Exists(packageDir)) {
+      return Array.Empty<string>();
+    }
+    // TODO: Validate version-ness, or just filter out any specific technical directories that might be known to exist.
+    return Directory.EnumerateDirectories(packageDir, "*.*", SearchOption.TopDirectoryOnly)
+                    .Select(dir => Path.GetFileName(dir) ?? "")
+                    .Where(dir => dir.Length > 0)
+                    .ToList();
+  }
+
   private string? NormalizePackageId(string id) {
     // TODO: More validation, maybe using a regex
     // FIXME: Or should this validation be included in a NormalizePackageId method?


### PR DESCRIPTION
This is the `/{LOWER_ID}/index.json` endpoint under package content. With this in place, `dotnet restore` works against this server.

Rename `PackageDownload` to `PackageContent`, because it isn't just downloading now.

Add a `PackageVersions` document.

Add a `GetPackageVersions` method to the package store.