### PR TITLE
Switch to GH actions for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
       run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
     - name: Run build script (${{matrix.configuration}})
-      run: pwsh -f ./build-package.ps1 -ContinuousIntegration -WithBinLog -Configuration ${{matrix.configuration}}
+      run: pwsh -f ./build-package.ps1 -Configuration ${{matrix.configuration}} -ContinuousIntegration -WithBinLog
     - name: "Artifact: MSBuild Logs"
       uses: actions/upload-artifact@v4
       if: failure()
@@ -43,4 +43,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Publish Output (${{matrix.configuration}})
-        path: "Zastai.NuGet.Server.zip"
+        path: gh-build-${{matrix.configuration}}/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+﻿name: Build
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      dotnet-version: 8.0.x
+    strategy:
+      matrix:
+        configuration: ['Debug', 'Release']
+
+    steps:
+    - name: Check out the project
+      uses: actions/checkout@v4
+    - name: Set up .NET ${{env.dotnet-version}}
+      uses: actions/setup-dotnet@v4
+      id: setup
+      with:
+        dotnet-version: ${{env.dotnet-version}}
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
+      run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
+    - name: Run build script (${{matrix.configuration}})
+      run: pwsh -f ./build-package.ps1 -ContinuousIntegration -WithBinLog -Configuration ${{matrix.configuration}}
+    - name: "Artifact: MSBuild Logs"
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: MSBuild Logs (${{matrix.configuration}})
+        path: msbuild.*.binlog
+    - name: "Artifact: Publish Output"
+      uses: actions/upload-artifact@v4
+      with:
+        name: Publish Output (${{matrix.configuration}})
+        path: "Zastai.NuGet.Server.zip"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.idea/
 /.vs/
 /.vscode/
+/publish/
 /test/
 bin/
 obj/
@@ -10,3 +11,4 @@ msbuild.*.binlog
 *.*proj.user
 *.DotSettings.user
 *.userprefs
+Zastai.NuGet.Server.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.idea/
 /.vs/
 /.vscode/
+/gh-build-*/
 /publish/
 /test/
 bin/

--- a/Zastai.NuGet.Server.sln
+++ b/Zastai.NuGet.Server.sln
@@ -8,7 +8,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Fi
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		appveyor.yml = appveyor.yml
 		build-package.ps1 = build-package.ps1
 		Directory.Packages.props = Directory.Packages.props
 		LICENSE.md = LICENSE.md
@@ -24,6 +23,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{7F5E5B
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Actions", "Actions", "{E68C3DBF-1BCF-4C19-9D83-3631DE1D151E}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\release-drafter.yml = .github\workflows\release-drafter.yml
 		.github\workflows\update-labels.yml = .github\workflows\update-labels.yml
 	EndProjectSection

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,0 @@
-version: 'Build #{build}'
-image: Visual Studio 2022
-build_script:
-  - pwsh: .\build-package.ps1 -Configuration Debug

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -1,25 +1,13 @@
-#Requires -Version 6.2
-#Requires -Modules @{ ModuleName = 'Microsoft.PowerShell.Archive'; ModuleVersion = '1.2.3' }
+#Requires -Version 5.1
 
 [CmdletBinding()]
 param (
   [string] $Configuration = 'Release',
-  [switch] $WithBinLog = $false
+  [switch] $ContinuousIntegration,
+  [switch] $WithBinLog
 )
 
-$opts = @( '--nologo' )
-if ($WithBinLog) {
-  $opts += '-bl'
-}
-
 $ErrorActionPreference = 'Stop'
-
-# The top-level folder used as target for the publish step (before being zipped).
-$PublishFolder = 'publish'
-
-# The zip file created after the publish step.
-# FIXME: Can we easily get any version info included in this name?
-$ZipFile = 'Zastai.NuGet.Server.zip'
 
 function Complete-BuildStep {
   param (
@@ -38,6 +26,24 @@ function Complete-BuildStep {
   }
 }
 
+$opts = @( '--nologo' )
+if ($WithBinLog) {
+  $opts += '-bl'
+}
+
+$props = @()
+if ($ContinuousIntegration) {
+  $props += '-p:ContinuousIntegrationBuild=true'
+  $props += '-p:Deterministic=true'
+}
+
+# The top-level folder used as target for the publish step (before being zipped).
+$PublishFolder = 'publish'
+
+# The zip file created after the publish step.
+# FIXME: Can we easily get any version info included in this name?
+$ZipFile = 'Zastai.NuGet.Server.zip'
+
 Write-Host 'Cleaning up existing build output...'
 Remove-Item -Recurse -Force */bin, */obj
 if (Test-Path $PublishFolder) {
@@ -50,7 +56,7 @@ dotnet restore $opts
 Complete-BuildStep 'restore' 'PACKAGE RESTORE'
 
 Write-Host "Building the solution (Configuration: $Configuration)..."
-dotnet build $opts --no-restore "-c:$Configuration" '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+dotnet build $opts --no-restore "-c:$Configuration" $props
 Complete-BuildStep 'build' 'SOLUTION BUILD'
 
 Write-Host 'Running tests...'
@@ -58,7 +64,8 @@ dotnet test $opts --no-build "-c:$Configuration"
 Complete-BuildStep 'test' 'UNIT TESTS'
 
 Write-Host 'Publishing...'
-dotnet publish $opts Zastai.NuGet.Server --no-build "-c:$Configuration" "-o:$PublishFolder"
+dotnet publish $opts PackageImport       --no-build "-c:$Configuration" "-o:$PublishFolder/importer"
+dotnet publish $opts Zastai.NuGet.Server --no-build "-c:$Configuration" "-o:$PublishFolder/server"
 Complete-BuildStep 'publish' 'PUBLISH'
 
 Write-Host 'Creating Zip File...'


### PR DESCRIPTION
This drops AppVeyor in favor of GH Actions.